### PR TITLE
Introduce History ignore accept feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: macOS
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14]
+        os: [macos-13, macos-14, macos-15, macos-latest]
     runs-on: ${{matrix.os}}
     steps:
       - name: Install deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Cache zsh
         id: cache-zsh
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /opt/zsh
           key: ${{runner.os}}-${{matrix.zsh-version}}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ This plugins define several `zle` widgets to run commands from the shell as vari
   - content is dump in a temporary file (`/tmp/zsh-quiet-accept-line-silent-$$.log` pattern). It can be configured with `ZLE_QAL_SILENT_DUMP_FILE` or disabled setting this env var to `/dev/null`
 - `last-quiet-accept-line` bound to <kbd>C-x C-k</kbd>: restore to the prompt the last command that was run with `quiet/silent-accept-line``
 
+- `history-ignore-accept-line`: run the current typed command prefixing it with a space so it's not stored in history
+  - bound to <kbd>C-x C-h</kbd> (overridable with `ZLE_QAL_HISTORY_IGNORE_KEY`)
+
+
 Optionaly status code of the quietly runned command can be display.
 To do so, set `ZLE_QAL_STATUS_DISPLAY` to `true`, `on` or `yes`.
 (`QAL` stands for *Quiet Accept Line*)
@@ -48,7 +52,7 @@ Just source [quiet-accept-line](./quiet-accept-line.zsh) content, or if you use 
 
 ## Configuration
 
-Keys can be configured based on the following variables and relatable defaults: `ZLE_QAL_QUIET_KEY` (`^X^M`), `ZLE_QAL_SILENT_KEY` (`^X^J`), `ZLE_QAL_COMPACT_KEY`, `ZLE_QAL_PAGER_KEY`/`ZLE_QAL_PAGER_KEY2` (`^X^\C-M`/`\e^\C-M`) and `ZLE_QAL_LAST_KEY`(`^X^K`).
+Keys can be configured based on the following variables and relatable defaults: `ZLE_QAL_QUIET_KEY` (`^X^M`), `ZLE_QAL_SILENT_KEY` (`^X^J`), `ZLE_QAL_COMPACT_KEY`, `ZLE_QAL_PAGER_KEY`/`ZLE_QAL_PAGER_KEY2` (`^X^\C-M`/`\e^\C-M`), `ZLE_QAL_LAST_KEY`(`^X^K`) and `ZLE_QAL_HISTORY_IGNORE_KEY` (`^X^ `)
 
 Output of the status code can be customized with the following variable:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This plugins define several `zle` widgets to run commands from the shell as vari
 - `last-quiet-accept-line` bound to <kbd>C-x C-k</kbd>: restore to the prompt the last command that was run with `quiet/silent-accept-line``
 
 - `history-ignore-accept-line`: run the current typed command prefixing it with a space so it's not stored in history
-  - bound to <kbd>C-x C-h</kbd> (overridable with `ZLE_QAL_HISTORY_IGNORE_KEY`)
+  - bound to <kbd>C-x C-SPC</kbd> (overridable with `ZLE_QAL_HISTORY_IGNORE_KEY`)
 
 
 Optionaly status code of the quietly runned command can be display.
@@ -52,7 +52,15 @@ Just source [quiet-accept-line](./quiet-accept-line.zsh) content, or if you use 
 
 ## Configuration
 
-Keys can be configured based on the following variables and relatable defaults: `ZLE_QAL_QUIET_KEY` (`^X^M`), `ZLE_QAL_SILENT_KEY` (`^X^J`), `ZLE_QAL_COMPACT_KEY`, `ZLE_QAL_PAGER_KEY`/`ZLE_QAL_PAGER_KEY2` (`^X^\C-M`/`\e^\C-M`), `ZLE_QAL_LAST_KEY`(`^X^K`) and `ZLE_QAL_HISTORY_IGNORE_KEY` (`^X^ `)
+Keys can be configured based on the following variables and relatable defaults:
+- `ZLE_QAL_QUIET_KEY` (default `^X^M`, <kbd>Ctrl-X</kbd> <kbd>Ctrl-M</kbd>)
+- `ZLE_QAL_SILENT_KEY` (default `^X^J`, <kbd>Ctrl-X</kbd> <kbd>Ctrl-J</kbd>)
+- `ZLE_QAL_COMPACT_KEY` (default `^N`, <kbd>Ctrl-N</kbd>)
+- `ZLE_QAL_PAGER_KEY` (default `^X^\C-M`, <kbd>Ctrl-X</kbd> <kbd>ESC</kbd> <kbd>Ctrl-M</kbd>)
+- `ZLE_QAL_PAGER_KEY2` (default `\e^\C-M`, <kbd>ESC</kbd> <kbd>Ctrl-M</kbd>)
+- `ZLE_QAL_LAST_KEY` (default `^X^K`, <kbd>Ctrl-X</kbd> <kbd>Ctrl-K</kbd>)
+- `ZLE_QAL_HISTORY_IGNORE_KEY` (default `^X^ `, <kbd>Ctrl-X</kbd> <kbd>Ctrl-Space</kbd>)
+
 
 Output of the status code can be customized with the following variable:
 

--- a/quiet-accept-line.plugin.zsh
+++ b/quiet-accept-line.plugin.zsh
@@ -131,3 +131,11 @@ function last-quiet-accept-line () {
 zle -N last-quiet-accept-line
 bindkey "${ZLE_QAL_LAST_KEY:-^X^K}" last-quiet-accept-line
 # TODO: turn into a ring!
+
+function history-ignore-accept-line () {
+    # Tweak buffer so it gets ignored by history according HIST_IGNORE_SPACE option
+    BUFFER=" ${BUFFER## }"
+    zle accept-line
+}
+zle -N history-ignore-accept-line
+bindkey "${ZLE_QAL_HISTORY_IGNORE_KEY:-^X^ }" history-ignore-accept-line # Ctrl+X Ctrl+Space

--- a/quiet-accept-line.plugin.zsh
+++ b/quiet-accept-line.plugin.zsh
@@ -99,7 +99,7 @@ function compact-accept-line () {
     zle accept-line;
 }
 zle -N compact-accept-line
-bindkey "${ZLE_QAL_COMPACT_KEY:-\C-N}" compact-accept-line
+bindkey "${ZLE_QAL_COMPACT_KEY:-^N}" compact-accept-line
 
 function silent-accept-line () {
     if [ -z "$BUFFER" ]; then return; fi

--- a/quiet-accept-line.plugin.zsh
+++ b/quiet-accept-line.plugin.zsh
@@ -122,6 +122,7 @@ bindkey "${ZLE_QAL_SILENT_KEY:-^X^\C-N}" silent-accept-line
 # +❗ add variants
 #   - for pager! page-accept-line (less/lets)
 #   -  to compact the prompt $ $BUFFER, result
+#   - maybe do not erase BUFFER if already populated
 # + Add qal cli to control var
 
 function last-quiet-accept-line () {
@@ -133,6 +134,7 @@ bindkey "${ZLE_QAL_LAST_KEY:-^X^K}" last-quiet-accept-line
 # TODO: turn into a ring!
 
 function history-ignore-accept-line () {
+    if [ -z "${BUFFER## }" ]; then return; fi
     # Tweak buffer so it gets ignored by history according HIST_IGNORE_SPACE option
     BUFFER=" ${BUFFER## }"
     zle accept-line


### PR DESCRIPTION
Add a new zle helper to easily prepend with space the command (:space_invader:)
(so that's it's not stored in the history cf `HIST_IGNORE_SPACE` zsh option) 

README structure improved